### PR TITLE
Demonstrate authenticated Action API request

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -7,16 +7,39 @@
     <div v-if="user">
       <h3>Welcome, {{ user.username }}</h3>
       <p>Click on the buttons above to navigate to different pages</p>
-      <p>This is an app, that does stufff...</p>
+      <p v-if="accessToken">
+        <span v-if="editCount">You have made {{ editCount }} Wikidata edits! 🎉</span>
+        <span v-else>Loading...</span>
+      </p>
     </div>
   </v-container>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
-import { getUser } from '../utils/storage';
+import { getAccessToken, getUser } from '../utils/storage';
 import NavBar from '../components/NavBar.vue';
 
 const user = ref(getUser());
+
+const accessToken = ref(getAccessToken());
+const editCount = ref(null);
+if (accessToken) {
+  fetch('https://www.wikidata.org/w/api.php?action=query&meta=userinfo&uiprop=editcount&format=json&formatversion=2&crossorigin=', {
+    headers: {
+      Authorization: `Bearer ${accessToken.value}`,
+    },
+    method: 'POST',
+  }).then(r => r.json()).then(r => {
+    const { userinfo } = r.query;
+    if (userinfo.name !== user.value.username) {
+      console.warning(`Inconsistent user name! OAuth "${user.value.username}" != MediaWiki "${userinfo.name}"`, r);
+      return;
+    }
+    editCount.value = r.query.userinfo.editcount;
+  }).catch(e => {
+    console.error('API request failed :( try logging out and back in again?', e);
+  });
+}
 
 </script>


### PR DESCRIPTION
This uses the recently-introduced `crossorigin=` parameter; see [T322944](https://phabricator.wikimedia.org/T322944) for details, or [m3api-examples][1] for another example using this.

Note that the access token is only valid for four hours (`$wgOAuth2GrantExpirationInterval`), and once it’s expired, the request will fail CORS, so we can’t even read the error message from the API. Make sure you **log out and back in** before trying this out.

[1]: https://github.com/lucaswerkmeister/m3api-examples/tree/main/webapp-clientside-vite-guestbook